### PR TITLE
Refactor Raspberry Pi music player into modules

### DIFF
--- a/pi_audio.py
+++ b/pi_audio.py
@@ -1,0 +1,71 @@
+# ================================================
+# FILE: pi_audio.py
+# ================================================
+"""Audio helper functions for the Raspberry Pi music player."""
+
+from __future__ import annotations
+
+import random
+import time
+from pathlib import Path
+
+try:
+    from pygame import mixer
+except ImportError:  # pragma: no cover - optional dependency
+    mixer = None  # type: ignore
+
+INTRO_AUDIO_DIR = Path("pir_prompts")
+CARD_INTRO_DIR = Path("card_intros")
+CARD_AUDIO_DIR = Path("card_audio")
+
+# Mapping of NFC card UID (hex string) to audio file name in CARD_AUDIO_DIR
+CARD_AUDIO_MAP: dict[str, str] = {
+    # Example: "04A1B2C3D4": "song1.mp3",
+}
+
+
+def init_audio() -> None:
+    """Initialize pygame mixer if available."""
+    if mixer:
+        mixer.init()
+
+
+def cleanup_audio() -> None:
+    """Cleanup pygame mixer."""
+    if mixer:
+        mixer.quit()
+
+
+def play_audio(file_path: Path) -> None:
+    """Play an audio file or log if mixer is unavailable."""
+    if not mixer:
+        print(f"Would play audio: {file_path}")
+        return
+    mixer.music.load(str(file_path))
+    mixer.music.play()
+    while mixer.music.get_busy():
+        time.sleep(0.1)
+
+
+def play_random_intro() -> None:
+    """Play a random introduction audio clip."""
+    files = list(INTRO_AUDIO_DIR.glob("*.mp3"))
+    if not files:
+        return
+    play_audio(random.choice(files))
+
+
+def play_card_intro(card_uid: str) -> None:
+    """Play card introduction audio if present."""
+    path = CARD_INTRO_DIR / f"{card_uid}.mp3"
+    if path.exists():
+        play_audio(path)
+
+
+def play_card_audio(card_uid: str) -> None:
+    """Play the audio mapped to a specific card UID."""
+    filename = CARD_AUDIO_MAP.get(card_uid)
+    if filename:
+        path = CARD_AUDIO_DIR / filename
+        if path.exists():
+            play_audio(path)

--- a/pi_sensors.py
+++ b/pi_sensors.py
@@ -1,0 +1,71 @@
+# ================================================
+# FILE: pi_sensors.py
+# ================================================
+"""GPIO and NFC helper functions for the Raspberry Pi music player."""
+
+from __future__ import annotations
+
+import time
+
+try:
+    import RPi.GPIO as GPIO
+except RuntimeError as exc:  # pragma: no cover - requires hardware
+    raise RuntimeError(
+        "This script must be run on a Raspberry Pi with RPi.GPIO installed"
+    ) from exc
+
+try:
+    from pn532 import PN532_I2C
+except ImportError:  # pragma: no cover - optional dependency
+    PN532_I2C = None  # type: ignore
+
+PIR_PIN = 17
+BUTTON_PIN = 27
+
+
+def setup_gpio() -> None:
+    """Configure GPIO pins."""
+    GPIO.setmode(GPIO.BCM)
+    GPIO.setup(PIR_PIN, GPIO.IN)
+    GPIO.setup(BUTTON_PIN, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+
+
+def cleanup_gpio() -> None:
+    """Reset GPIO configuration."""
+    GPIO.cleanup()
+
+
+def init_nfc_reader():
+    """Initialize the PN532 reader if available."""
+    if PN532_I2C:
+        pn532 = PN532_I2C(debug=False)
+        pn532.SAM_configuration()
+        return pn532
+    return None
+
+
+def wait_for_button(timeout: float) -> bool:
+    """Return True if the button is pressed within timeout seconds."""
+    start = time.monotonic()
+    while time.monotonic() - start < timeout:
+        if GPIO.input(BUTTON_PIN) == GPIO.LOW:
+            while GPIO.input(BUTTON_PIN) == GPIO.LOW:
+                time.sleep(0.05)
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def read_nfc_uid(pn532) -> str | None:
+    """Read an NFC UID if present."""
+    if not pn532:
+        return None
+    uid = pn532.read_passive_target(timeout=0.5)
+    if uid:
+        return "".join(f"{x:02X}" for x in uid)
+    return None
+
+
+def is_pir_triggered() -> bool:
+    """Return True if the PIR sensor is active."""
+    return GPIO.input(PIR_PIN) == GPIO.HIGH

--- a/raspberry_music_player.py
+++ b/raspberry_music_player.py
@@ -1,0 +1,59 @@
+# ================================================
+# FILE: raspberry_music_player.py
+# ================================================
+"""Main orchestrator for PIR and NFC based music playback."""
+
+from __future__ import annotations
+
+import time
+
+from pi_audio import (
+    init_audio,
+    cleanup_audio,
+    play_random_intro,
+    play_card_intro,
+    play_card_audio,
+)
+from pi_sensors import (
+    setup_gpio,
+    cleanup_gpio,
+    init_nfc_reader,
+    read_nfc_uid,
+    wait_for_button,
+    is_pir_triggered,
+)
+
+COOLDOWN_SECONDS = 30 * 60  # 30 minutes
+
+
+def main() -> None:
+    setup_gpio()
+    init_audio()
+    pn532 = init_nfc_reader()
+    last_trigger = 0
+
+    try:
+        while True:
+            if is_pir_triggered():
+                now = time.monotonic()
+                if now - last_trigger > COOLDOWN_SECONDS:
+                    last_trigger = now
+                    play_random_intro()
+
+            uid = read_nfc_uid(pn532)
+            if uid:
+                play_card_intro(uid)
+                for _ in range(10):
+                    print("Press the button to play the song…")
+                    if wait_for_button(10):
+                        play_card_audio(uid)
+                        break
+
+            time.sleep(0.1)
+    finally:
+        cleanup_gpio()
+        cleanup_audio()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- break monolithic Raspberry Pi script into separate modules
- `pi_audio.py` manages audio playback
- `pi_sensors.py` handles GPIO and NFC helpers
- update `raspberry_music_player.py` to use new modules

## Testing
- `python -m py_compile pi_audio.py pi_sensors.py raspberry_music_player.py`


------
https://chatgpt.com/codex/tasks/task_e_68838f62eae8832289d2412556437761