### PR TITLE
Refactor NFC code to use libnfc

### DIFF
--- a/music_player/audio_utils.py
+++ b/music_player/audio_utils.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import time
+
+try:
+    from pygame import mixer
+except ImportError:  # pragma: no cover - optional dependency
+    mixer = None
+
+
+def init() -> None:
+    """Initialize the mixer if available."""
+    if mixer and not mixer.get_init():
+        mixer.init()
+
+
+def quit() -> None:
+    """Quit the mixer if it was initialized."""
+    if mixer and mixer.get_init():
+        mixer.quit()
+
+
+def play_audio(file_path: Path) -> None:
+    """Play an audio file using pygame if available."""
+    if not mixer:
+        print(f"Would play audio: {file_path}")
+        return
+    mixer.music.load(str(file_path))
+    mixer.music.play()
+    while mixer.music.get_busy():
+        time.sleep(0.1)

--- a/music_player/nfc_handler.py
+++ b/music_player/nfc_handler.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+import time
+
+try:
+    import RPi.GPIO as GPIO
+except RuntimeError:  # pragma: no cover - requires hardware
+    raise RuntimeError("This script must be run on a Raspberry Pi with RPi.GPIO installed")
+
+try:
+    import nfc
+except ImportError:  # pragma: no cover - optional dependency
+    nfc = None  # type: ignore
+
+from .audio_utils import play_audio
+
+BUTTON_PIN = 27
+CARD_INTRO_DIR = Path("card_intros")
+CARD_AUDIO_DIR = Path("card_audio")
+CARD_AUDIO_MAP: dict[str, str] = {}
+BUTTON_PROMPT_AUDIO = Path("button_prompt.mp3")
+
+GPIO.setup(BUTTON_PIN, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+
+
+def open_clf() -> "nfc.ContactlessFrontend | None":
+    """Open the NFC contactless frontend using libnfc if available."""
+    if not nfc:
+        return None
+    try:
+        return nfc.ContactlessFrontend("pn532")
+    except Exception:
+        return None
+
+
+
+def read_nfc_uid(clf) -> str | None:
+    """Read an NFC UID using nfcpy."""
+    if not clf:
+        return None
+    try:
+        tag = clf.connect(rdwr={"on-connect": lambda tag: False}, timeout=0.5)
+    except Exception:
+        return None
+    if tag is not None:
+        if hasattr(tag, "identifier"):
+            return tag.identifier.hex().upper()
+    return None
+
+
+def wait_for_button(timeout: float) -> bool:
+    start = time.monotonic()
+    while time.monotonic() - start < timeout:
+        if GPIO.input(BUTTON_PIN) == GPIO.LOW:
+            while GPIO.input(BUTTON_PIN) == GPIO.LOW:
+                time.sleep(0.05)
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def play_card_intro(card_uid: str) -> None:
+    path = CARD_INTRO_DIR / f"{card_uid}.mp3"
+    if path.exists():
+        play_audio(path)
+
+
+def play_card_audio(card_uid: str) -> None:
+    filename = CARD_AUDIO_MAP.get(card_uid)
+    if filename:
+        path = CARD_AUDIO_DIR / filename
+        if path.exists():
+            play_audio(path)
+
+
+def prompt_button_press(repeat: int = 10, interval: float = 10.0) -> bool:
+    """Prompt the user to press the button and wait for it."""
+    for _ in range(repeat):
+        if BUTTON_PROMPT_AUDIO.exists():
+            play_audio(BUTTON_PROMPT_AUDIO)
+        else:
+            print("Please press the button")
+        if wait_for_button(interval):
+            return True
+    return False

--- a/music_player/pir_handler.py
+++ b/music_player/pir_handler.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import random
+import time
+
+try:
+    import RPi.GPIO as GPIO
+except RuntimeError:  # pragma: no cover - requires hardware
+    raise RuntimeError("This script must be run on a Raspberry Pi with RPi.GPIO installed")
+
+from .audio_utils import play_audio
+
+PIR_PIN = 17
+COOLDOWN_SECONDS = 30 * 60  # 30 minutes
+INTRO_AUDIO_DIR = Path("pir_prompts")
+
+last_trigger = 0.0
+
+GPIO.setmode(GPIO.BCM)
+GPIO.setup(PIR_PIN, GPIO.IN)
+
+
+def play_random_intro() -> None:
+    files = list(INTRO_AUDIO_DIR.glob("*.mp3"))
+    if files:
+        play_audio(random.choice(files))
+
+
+def handle_pir() -> None:
+    """Check PIR sensor and play intro if cooldown elapsed."""
+    global last_trigger
+    if GPIO.input(PIR_PIN):
+        now = time.monotonic()
+        if now - last_trigger > COOLDOWN_SECONDS:
+            last_trigger = now
+            play_random_intro()

--- a/raspberry_music_player.py
+++ b/raspberry_music_player.py
@@ -1,0 +1,36 @@
+from time import sleep
+import RPi.GPIO as GPIO
+
+from music_player.pir_handler import handle_pir
+from music_player.nfc_handler import (
+    open_clf,
+    read_nfc_uid,
+    play_card_intro,
+    play_card_audio,
+    prompt_button_press,
+)
+from music_player import audio_utils
+
+
+def main() -> None:
+    audio_utils.init()
+    clf = open_clf()
+
+    try:
+        while True:
+            handle_pir()
+            uid = read_nfc_uid(clf)
+            if uid:
+                play_card_intro(uid)
+                if prompt_button_press():
+                    play_card_audio(uid)
+            sleep(0.1)
+    finally:
+        if clf:
+            clf.close()
+        GPIO.cleanup()
+        audio_utils.quit()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- use `nfcpy` (libnfc) instead of Adafruit's PN532 library
- open the contactless frontend with `open_clf()`
- clean up the NFC device on exit
- add button prompt audio to repeat when waiting for a press

## Testing
- `python -m py_compile raspberry_music_player.py music_player/audio_utils.py music_player/pir_handler.py music_player/nfc_handler.py`
- `ruff check raspberry_music_player.py music_player/audio_utils.py music_player/pir_handler.py music_player/nfc_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_68838f62eae8832289d2412556437761